### PR TITLE
Small typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Grab the package using NuGet
 
            switch (gesture)
            {
-        	   case (GestureType.JointHands): break;
+        	   case (GestureType.JoinedHands): break;
         	   case (GestureType.Menu): break;
         	   case (GestureType.SwipeDown): break;
         	   case (GestureType.SwipeLeft): break;


### PR DESCRIPTION
Changed case (GestureType.JointHands): break; to case (GestureType.JoinedHands): break;
